### PR TITLE
Add Lisp tokenizer module with tests

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,0 +1,2 @@
+(lang dune 3.6)
+(name lisp)

--- a/lisp.opam
+++ b/lisp.opam
@@ -1,0 +1,7 @@
+opam-version: "2.0"
+name: "lisp"
+version: "0.1"
+authors: "Auto"
+maintainer: "auto@example.com"
+synopsis: "Educational Lisp interpreter"
+depends: [ "ocaml" "dune" "ounit2" ]

--- a/src/dune
+++ b/src/dune
@@ -1,0 +1,12 @@
+(library
+ (name lisp)
+ (wrapped false)
+ (public_name lisp)
+ (modules token lexer)
+)
+
+(test
+ (name lexer_test)
+ (modules lexer_test)
+ (libraries lisp ounit2)
+)

--- a/src/lexer.ml
+++ b/src/lexer.ml
@@ -1,0 +1,86 @@
+(** Lexer for the mini Lisp interpreter.
+    It converts an input string into a list of {!Token.t} values.
+
+    The implementation walks over the input character by character,
+    building tokens for parentheses, numbers, strings and symbols.
+    Whitespace separates tokens and is otherwise ignored.
+*)
+
+open Token
+
+let is_whitespace = function
+  | ' ' | '\n' | '\t' | '\r' -> true
+  | _ -> false
+
+let is_digit c = c >= '0' && c <= '9'
+
+(* [read_number s i] reads a numeric literal starting at index [i].
+   It returns the parsed float and the position immediately after the
+   literal. Only decimal numbers are supported for now. *)
+let read_number s i =
+  let len = String.length s in
+  let rec aux j =
+    if j < len then
+      match s.[j] with
+      | c when is_digit c || c = '.' -> aux (j + 1)
+      | _ -> j
+    else j
+  in
+  let j = aux i in
+  let substr = String.sub s i (j - i) in
+  let value = float_of_string substr in
+  (Number value, j)
+
+(* [read_symbol s i] reads a symbol starting at index [i].
+   A symbol is any sequence of characters that does not contain
+   whitespace or parentheses. *)
+let read_symbol s i =
+  let len = String.length s in
+  let rec aux j =
+    if j < len then
+      match s.[j] with
+      | '(' | ')' | '"' -> j (* stop before delimiters *)
+      | c when is_whitespace c -> j
+      | _ -> aux (j + 1)
+    else j
+  in
+  let j = aux i in
+  let substr = String.sub s i (j - i) in
+  (Symbol substr, j)
+
+(* [read_string s i] reads a string literal starting at index [i].
+   Strings are delimited by double quotes. Escapes are not yet supported. *)
+let read_string s i =
+  let len = String.length s in
+  let rec aux j =
+    if j < len then
+      match s.[j] with
+      | '"' -> j
+      | _ -> aux (j + 1)
+    else failwith "Unterminated string"
+  in
+  let j = aux (i + 1) in
+  let substr = String.sub s (i + 1) (j - i - 1) in
+  (String substr, j + 1)
+
+(* Main tokenization function. *)
+let tokenize s =
+  let len = String.length s in
+  let rec aux i acc =
+    if i >= len then List.rev acc
+    else
+      match s.[i] with
+      | c when is_whitespace c -> aux (i + 1) acc
+      | '(' -> aux (i + 1) (LParen :: acc)
+      | ')' -> aux (i + 1) (RParen :: acc)
+      | '"' ->
+          let (tok, j) = read_string s i in
+          aux j (tok :: acc)
+      | c when is_digit c || (c = '-' && i + 1 < len && is_digit s.[i + 1]) ->
+          let (tok, j) = read_number s i in
+          aux j (tok :: acc)
+      | _ ->
+          let (tok, j) = read_symbol s i in
+          aux j (tok :: acc)
+  in
+  aux 0 []

--- a/src/lexer.mli
+++ b/src/lexer.mli
@@ -1,0 +1,4 @@
+(** Tokenizer for the Lisp interpreter. *)
+
+val tokenize : string -> Token.t list
+(** [tokenize s] converts the string [s] into a list of tokens. *)

--- a/src/lexer_test.ml
+++ b/src/lexer_test.ml
@@ -1,0 +1,14 @@
+open OUnit2
+
+let test_simple _ =
+  let open Token in
+  let tokens = Lexer.tokenize "(+ 1 2)" in
+  let expected = [LParen; Symbol "+"; Number 1.; Number 2.; RParen] in
+  assert_equal ~printer:(fun ts -> String.concat "," (List.map (function
+    | LParen -> "(" | RParen -> ")" | Number n -> string_of_float n
+    | String s -> Printf.sprintf "\"%s\"" s | Symbol s -> s) ts))
+    expected tokens
+
+let suite = "lexer" >::: ["simple" >:: test_simple]
+
+let () = run_test_tt_main suite

--- a/src/token.ml
+++ b/src/token.ml
@@ -1,0 +1,6 @@
+type t =
+  | LParen
+  | RParen
+  | Number of float
+  | String of string
+  | Symbol of string

--- a/src/token.mli
+++ b/src/token.mli
@@ -1,0 +1,8 @@
+(** Representation of tokens recognized by the lexer. *)
+
+type t =
+  | LParen        (** '(' character *)
+  | RParen        (** ')' character *)
+  | Number of float  (** numeric literal *)
+  | String of string (** string literal without quotes *)
+  | Symbol of string (** symbol or identifier *)


### PR DESCRIPTION
## Summary
- implement `Token` type and `Lexer.tokenize` for Lisp interpreter
- configure dune and opam project
- add unit test for tokenizer

## Testing
- `dune runtest --display=short`

------
https://chatgpt.com/codex/tasks/task_e_6853fe9c6a10832ba09ab57fd55d0bfd